### PR TITLE
fix(Dockerfile): Use production version of upstream image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN npm run build
 
 RUN npm prune --production
 
-FROM ghcr.io/hazmi35/node:18-dev-alpine
+FROM ghcr.io/hazmi35/node:18-alpine
 
 LABEL name "Scheduled Tasks Production"
 LABEL maintainer "KagChi"


### PR DESCRIPTION
As intended in https://github.com/Hazmi35/docker-node\#information-for-dev-version